### PR TITLE
[WIP] POC to support new Dashboard API

### DIFF
--- a/datadog/datadog_dashboard_widget.go
+++ b/datadog/datadog_dashboard_widget.go
@@ -1,0 +1,549 @@
+package datadog
+
+import (
+	"fmt"
+	"strconv"
+
+	datadog "github.com/MLaureB/go-datadog-api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+//
+// Template Variable helpers
+//
+
+func getTemplateVariableSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the variable.",
+		},
+		"prefix": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.",
+		},
+		"default": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The default value for the template variable on dashboard load.",
+		},
+	}
+}
+
+func buildDatadogTemplateVariables(terraformTemplateVariables *[]interface{}) *[]datadog.TemplateVariable {
+	datadogTemplateVariables := make([]datadog.TemplateVariable, len(*terraformTemplateVariables))
+	for i, _templateVariable := range *terraformTemplateVariables {
+		templateVariable := _templateVariable.(map[string]interface{})
+		datadogTemplateVariables[i] = datadog.TemplateVariable{
+			Name:    datadog.String(templateVariable["name"].(string)),
+			Prefix:  datadog.String(templateVariable["prefix"].(string)),
+			Default: datadog.String(templateVariable["default"].(string)),
+		}
+	}
+	return &datadogTemplateVariables
+}
+
+func buildTerraformTemplateVariables(datadogTemplateVariables *[]datadog.TemplateVariable) *[]map[string]string {
+	terraformTemplateVariables := make([]map[string]string, len(*datadogTemplateVariables))
+	for i, templateVariable := range *datadogTemplateVariables {
+		terraformTemplateVariable := map[string]string{}
+		// Required params
+		terraformTemplateVariable["name"] = *templateVariable.Name
+		// Optional params
+		if templateVariable.Prefix != nil {
+			terraformTemplateVariable["prefix"] = *templateVariable.Prefix
+		}
+		if templateVariable.Default != nil {
+			terraformTemplateVariable["default"] = *templateVariable.Default
+		}
+		terraformTemplateVariables[i] = terraformTemplateVariable
+	}
+	return &terraformTemplateVariables
+}
+
+//
+// Notify List helpers
+//
+
+func buildDatadogNotifyList(terraformNotifyList *[]interface{}) []string {
+	datadogNotifyList := make([]string, len(*terraformNotifyList))
+	for i, authorHandle := range *terraformNotifyList {
+		datadogNotifyList[i] = authorHandle.(string)
+	}
+	return datadogNotifyList
+}
+
+func buildTerraformNotifyList(datadogNotifyList *[]string) []string {
+	terraformNotifyList := make([]string, len(*datadogNotifyList))
+	for i, authorHandle := range *datadogNotifyList {
+		terraformNotifyList[i] = authorHandle
+	}
+	return terraformNotifyList
+}
+
+//
+// Widgets helpers
+//
+
+// The generic widget schema is a combinaison of the schema for a non-group widget
+// and the schema for a Group Widget (which can contains only non-group widgets)
+func getWidgetSchema() map[string]*schema.Schema {
+	widgetSchema := getNonGroupWidgetSchema()
+	widgetSchema["group_definition"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "The definition for a Group widget",
+		Elem: &schema.Resource{
+			Schema: getGroupDefinitionSchema(),
+		},
+	}
+	return widgetSchema
+}
+
+// Schema for a non-group widget
+func getNonGroupWidgetSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"layout": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Description: "The layout of the widget on a 'free' dashboard",
+			Elem: &schema.Resource{
+				Schema: getWidgetLayoutSchema(),
+			},
+		},
+		// A widget should implement exactly one of the following definitions
+		"alert_graph_definition": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "The definition for an Alert Graph widget",
+			Elem: &schema.Resource{
+				Schema: getAlertGraphDefinitionSchema(),
+			},
+		},
+		"note_definition": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "The definition for a Note widget",
+			Elem: &schema.Resource{
+				Schema: getNoteDefinitionSchema(),
+			},
+		},
+	}
+}
+
+// Helper to build a list of Datadog widgets from a list of Terraform widgets
+func buildDatadogWidgets(terraformWidgets *[]interface{}) (*[]datadog.BoardWidget, error) {
+	datadogWidgets := make([]datadog.BoardWidget, len(*terraformWidgets))
+	for i, terraformWidget := range *terraformWidgets {
+		datadogWidget, err := buildDatadogWidget(terraformWidget.(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		datadogWidgets[i] = *datadogWidget
+	}
+	return &datadogWidgets, nil
+}
+
+// Helper to build a Datadog widget from a Terraform widget
+func buildDatadogWidget(terraformWidget map[string]interface{}) (*datadog.BoardWidget, error) {
+	datadogWidget := datadog.BoardWidget{}
+
+	// Build widget Layout
+	if layout, ok := terraformWidget["layout"].(map[string]interface{}); ok && len(layout) > 0 {
+		datadogWidget.Layout = buildDatadogWidgetLayout(layout)
+	}
+
+	// Build widget Definition
+	if _def, ok := terraformWidget["alert_graph_definition"].([]interface{}); ok && len(_def) > 0 {
+		if alertGraphDefinition, ok := _def[0].(map[string]interface{}); ok {
+			datadogWidget.Definition = buildDatadogAlertGraphDefinition(alertGraphDefinition)
+		}
+	} else if _def, ok := terraformWidget["note_definition"].([]interface{}); ok && len(_def) > 0 {
+		if noteDefinition, ok := _def[0].(map[string]interface{}); ok {
+			datadogWidget.Definition = buildDatadogNoteDefinition(noteDefinition)
+		}
+	} else if _def, ok := terraformWidget["group_definition"].([]interface{}); ok && len(_def) > 0 {
+		if groupDefinition, ok := _def[0].(map[string]interface{}); ok {
+			datadogDefinition, err := buildDatadogGroupDefinition(groupDefinition)
+			if err != nil {
+				return nil, err
+			}
+			datadogWidget.Definition = datadogDefinition
+		}
+	} else {
+		return nil, fmt.Errorf("Failed to find valid definition in widget configuration")
+	}
+
+	return &datadogWidget, nil
+}
+
+// Helper to build a list of Terraform widgets from a list of Datadog widgets
+func buildTerraformWidgets(datadogWidgets *[]datadog.BoardWidget) (*[]map[string]interface{}, error) {
+	terraformWidgets := make([]map[string]interface{}, len(*datadogWidgets))
+	for i, datadogWidget := range *datadogWidgets {
+		terraformWidget, err := buildTerraformWidget(datadogWidget)
+		if err != nil {
+			return nil, err
+		}
+		terraformWidgets[i] = terraformWidget
+	}
+	return &terraformWidgets, nil
+}
+
+// Helper to build a Terraform widget from a Datadog widget
+func buildTerraformWidget(datadogWidget datadog.BoardWidget) (map[string]interface{}, error) {
+	terraformWidget := map[string]interface{}{}
+
+	// Build layout
+	if datadogWidget.Layout != nil {
+		terraformWidget["layout"] = buildTerraformWidgetLayout(*datadogWidget.Layout)
+	}
+
+	// Build definition
+	widgetType, err := datadogWidget.GetWidgetType()
+	if err != nil {
+		return nil, err
+	}
+	switch widgetType {
+	case datadog.ALERT_GRAPH_WIDGET:
+		datadogDefinition := datadogWidget.Definition.(datadog.AlertGraphDefinition)
+		terraformDefinition := buildTerraformAlertGraphDefinition(datadogDefinition)
+		terraformWidget["alert_graph_definition"] = []map[string]interface{}{terraformDefinition}
+	case datadog.NOTE_WIDGET:
+		datadogDefinition := datadogWidget.Definition.(datadog.NoteDefinition)
+		terraformDefinition := buildTerraformNoteDefinition(datadogDefinition)
+		terraformWidget["note_definition"] = []map[string]interface{}{terraformDefinition}
+	case datadog.GROUP_WIDGET:
+		datadogDefinition := datadogWidget.Definition.(datadog.GroupDefinition)
+		terraformDefinition := buildTerraformGroupDefinition(datadogDefinition)
+		terraformWidget["group_definition"] = []map[string]interface{}{terraformDefinition}
+	default:
+		return nil, fmt.Errorf("Unsupported widget type: %s", widgetType)
+	}
+
+	return terraformWidget, nil
+}
+
+//
+// Widget Layout helpers
+//
+
+func getWidgetLayoutSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"x": {
+			Type:     schema.TypeFloat,
+			Required: true,
+		},
+		"y": {
+			Type:     schema.TypeFloat,
+			Required: true,
+		},
+		"width": {
+			Type:     schema.TypeFloat,
+			Required: true,
+		},
+		"height": {
+			Type:     schema.TypeFloat,
+			Required: true,
+		},
+	}
+}
+
+func buildDatadogWidgetLayout(terraformLayout map[string]interface{}) *datadog.WidgetLayout {
+	datadogLayout := &datadog.WidgetLayout{}
+	if v, err := strconv.ParseFloat(terraformLayout["x"].(string), 64); err == nil {
+		datadogLayout.X = &v
+	}
+	if v, err := strconv.ParseFloat(terraformLayout["y"].(string), 64); err == nil {
+		datadogLayout.Y = &v
+	}
+	if v, err := strconv.ParseFloat(terraformLayout["height"].(string), 64); err == nil {
+		datadogLayout.Height = &v
+	}
+	if v, err := strconv.ParseFloat(terraformLayout["width"].(string), 64); err == nil {
+		datadogLayout.Width = &v
+	}
+	return datadogLayout
+}
+
+func buildTerraformWidgetLayout(datadogLayout datadog.WidgetLayout) map[string]string {
+	terraformLayout := map[string]string{}
+	if datadogLayout.X != nil {
+		terraformLayout["x"] = strconv.FormatFloat(*datadogLayout.X, 'f', -1, 64)
+	}
+	if datadogLayout.Y != nil {
+		terraformLayout["y"] = strconv.FormatFloat(*datadogLayout.Y, 'f', -1, 64)
+	}
+	if datadogLayout.Height != nil {
+		terraformLayout["height"] = strconv.FormatFloat(*datadogLayout.Height, 'f', -1, 64)
+	}
+	if datadogLayout.Width != nil {
+		terraformLayout["width"] = strconv.FormatFloat(*datadogLayout.Width, 'f', -1, 64)
+	}
+	return terraformLayout
+}
+
+//
+// Alert Graph Definition helpers
+//
+
+func getAlertGraphDefinitionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"alert_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"viz_type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"title": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"title_size": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"title_align": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"time": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: getWidgetTimeSchema(),
+			},
+		},
+	}
+}
+
+func buildDatadogAlertGraphDefinition(terraformDefinition map[string]interface{}) *datadog.AlertGraphDefinition {
+	datadogDefinition := &datadog.AlertGraphDefinition{}
+	// Required params
+	datadogDefinition.Type = datadog.String(datadog.ALERT_GRAPH_WIDGET)
+	datadogDefinition.AlertId = datadog.String(terraformDefinition["alert_id"].(string))
+	datadogDefinition.VizType = datadog.String(terraformDefinition["viz_type"].(string))
+	// Optional params
+	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
+		datadogDefinition.Title = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["title_size"].(string); ok && len(v) != 0 {
+		datadogDefinition.TitleSize = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["title_align"].(string); ok && len(v) != 0 {
+		datadogDefinition.TitleAlign = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["time"].(map[string]interface{}); ok && len(v) > 0 {
+		datadogDefinition.Time = buildDatadogWidgetTime(v)
+	}
+	return datadogDefinition
+}
+
+func buildTerraformAlertGraphDefinition(datadogDefinition datadog.AlertGraphDefinition) map[string]interface{} {
+	terraformDefinition := map[string]interface{}{}
+	// Required params
+	terraformDefinition["alert_id"] = *datadogDefinition.AlertId
+	terraformDefinition["viz_type"] = *datadogDefinition.VizType
+	// Optional params
+	if datadogDefinition.Title != nil {
+		terraformDefinition["title"] = *datadogDefinition.Title
+	}
+	if datadogDefinition.TitleSize != nil {
+		terraformDefinition["title_size"] = *datadogDefinition.TitleSize
+	}
+	if datadogDefinition.TitleAlign != nil {
+		terraformDefinition["title_align"] = *datadogDefinition.TitleAlign
+	}
+	if datadogDefinition.Time != nil {
+		terraformDefinition["time"] = buildTerraformWidgetTime(*datadogDefinition.Time)
+	}
+	return terraformDefinition
+}
+
+//
+// Group Widget Definition helpers
+//
+
+func getGroupDefinitionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"layout_type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"widget": {
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "The list of widgets in this group.",
+			Elem: &schema.Resource{
+				Schema: getNonGroupWidgetSchema(),
+			},
+		},
+		"title": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func buildDatadogGroupDefinition(terraformDefinition map[string]interface{}) (*datadog.GroupDefinition, error) {
+	datadogDefinition := &datadog.GroupDefinition{}
+	// Required params
+	datadogDefinition.Type = datadog.String(datadog.GROUP_WIDGET)
+	if v, ok := terraformDefinition["layout_type"].(string); ok && len(v) != 0 {
+		datadogDefinition.LayoutType = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["widget"].([]interface{}); ok {
+		groupWidgets, err := buildDatadogWidgets(&v)
+		if err != nil {
+			return nil, err
+		}
+		datadogDefinition.Widgets = *groupWidgets
+	}
+	// Optional params
+	if v, ok := terraformDefinition["title"].(string); ok && len(v) != 0 {
+		datadogDefinition.Title = datadog.String(v)
+	}
+	return datadogDefinition, nil
+}
+
+func buildTerraformGroupDefinition(datadogDefinition datadog.GroupDefinition) map[string]interface{} {
+	terraformDefinition := map[string]interface{}{}
+	// Required params
+	terraformDefinition["layout_type"] = *datadogDefinition.LayoutType
+	groupWidgets := []map[string]interface{}{}
+	for _, datadogGroupWidgets := range datadogDefinition.Widgets {
+		newGroupWidget, _ := buildTerraformWidget(datadogGroupWidgets)
+		groupWidgets = append(groupWidgets, newGroupWidget)
+	}
+	terraformDefinition["widget"] = groupWidgets
+	// Optional params
+	if datadogDefinition.Title != nil {
+		terraformDefinition["title"] = *datadogDefinition.Title
+	}
+	return terraformDefinition
+}
+
+//
+// Note Widget Definition helpers
+//
+
+func getNoteDefinitionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"content": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"background_color": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"font_size": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"text_align": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"show_tick": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"tick_pos": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"tick_edge": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func buildDatadogNoteDefinition(terraformDefinition map[string]interface{}) *datadog.NoteDefinition {
+	datadogDefinition := &datadog.NoteDefinition{}
+	// Required params
+	datadogDefinition.Type = datadog.String(datadog.NOTE_WIDGET)
+	datadogDefinition.Content = datadog.String(terraformDefinition["content"].(string))
+	// Optional params
+	if v, ok := terraformDefinition["background_color"].(string); ok && len(v) != 0 {
+		datadogDefinition.BackgroundColor = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["font_size"].(string); ok && len(v) != 0 {
+		datadogDefinition.FontSize = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["text_align"].(string); ok && len(v) != 0 {
+		datadogDefinition.TextAlign = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["show_tick"]; ok {
+		datadogDefinition.ShowTick = datadog.Bool(v.(bool))
+	}
+	if v, ok := terraformDefinition["tick_pos"].(string); ok && len(v) != 0 {
+		datadogDefinition.TickPos = datadog.String(v)
+	}
+	if v, ok := terraformDefinition["tick_edge"].(string); ok && len(v) != 0 {
+		datadogDefinition.TickEdge = datadog.String(v)
+	}
+	return datadogDefinition
+}
+
+func buildTerraformNoteDefinition(datadogDefinition datadog.NoteDefinition) map[string]interface{} {
+	terraformDefinition := map[string]interface{}{}
+	// Required params
+	terraformDefinition["content"] = *datadogDefinition.Content
+	// Optional params
+	if datadogDefinition.BackgroundColor != nil {
+		terraformDefinition["background_color"] = *datadogDefinition.BackgroundColor
+	}
+	if datadogDefinition.FontSize != nil {
+		terraformDefinition["font_size"] = *datadogDefinition.FontSize
+	}
+	if datadogDefinition.TextAlign != nil {
+		terraformDefinition["text_align"] = *datadogDefinition.TextAlign
+	}
+	if datadogDefinition.ShowTick != nil {
+		terraformDefinition["show_tick"] = *datadogDefinition.ShowTick
+	}
+	if datadogDefinition.TickPos != nil {
+		terraformDefinition["tick_pos"] = *datadogDefinition.TickPos
+	}
+	if datadogDefinition.TickEdge != nil {
+		terraformDefinition["tick_edge"] = *datadogDefinition.TickEdge
+	}
+	return terraformDefinition
+}
+
+//
+// Helpers common to different widget definitions
+//
+
+// Widget Time
+func getWidgetTimeSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"live_span": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+func buildDatadogWidgetTime(terraformWidgetTime map[string]interface{}) *datadog.WidgetTime {
+	datadogWidgetTime := &datadog.WidgetTime{}
+	if v, ok := terraformWidgetTime["live_span"].(string); ok && len(v) != 0 {
+		datadogWidgetTime.LiveSpan = datadog.String(v)
+	}
+	return datadogWidgetTime
+}
+func buildTerraformWidgetTime(datadogWidgetTime datadog.WidgetTime) map[string]string {
+	terraformWidgetTime := map[string]string{}
+	if datadogWidgetTime.LiveSpan != nil {
+		terraformWidgetTime["live_span"] = *datadogWidgetTime.LiveSpan
+	}
+	return terraformWidgetTime
+}

--- a/datadog/provider.go
+++ b/datadog/provider.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"log"
 
+	datadog "github.com/zorkian/go-datadog-api"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	datadog "github.com/zorkian/go-datadog-api"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -37,6 +37,7 @@ func Provider() terraform.ResourceProvider {
 			"datadog_monitor":               resourceDatadogMonitor(),
 			"datadog_timeboard":             resourceDatadogTimeboard(),
 			"datadog_screenboard":           resourceDatadogScreenboard(),
+			"datadog_dashboard":             resourceDatadogDashboard(),
 			"datadog_user":                  resourceDatadogUser(),
 			"datadog_integration_gcp":       resourceDatadogIntegrationGcp(),
 			"datadog_integration_aws":       resourceDatadogIntegrationAws(),

--- a/datadog/resource_datadog_dashboard.go
+++ b/datadog/resource_datadog_dashboard.go
@@ -1,0 +1,194 @@
+package datadog
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/MLaureB/go-datadog-api"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/kr/pretty"
+)
+
+func resourceDatadogDashboard() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDatadogDashboardCreate,
+		Update: resourceDatadogDashboardUpdate,
+		Read:   resourceDatadogDashboardRead,
+		Delete: resourceDatadogDashboardDelete,
+		Exists: resourceDatadogDashboardExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceDatadogDashboardImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The title of the dashboard.",
+			},
+			"widget": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "The list of widgets to display on the dashboard.",
+				Elem: &schema.Resource{
+					Schema: getWidgetSchema(),
+				},
+			},
+			"layout_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The layout type of the dashboard, either 'free' or 'ordered'.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the dashboard.",
+			},
+			"is_read_only": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether this dashboard is read-only.",
+			},
+			"template_variable": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The list of template variables for this dashboard.",
+				Elem: &schema.Resource{
+					Schema: getTemplateVariableSchema(),
+				},
+			},
+			"notify_list": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The list of handles of users to notify when changes are made to this dashboard.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildDatadogDashboard(d *schema.ResourceData) (*datadog.Board, error) {
+	// Build Dashboard metadata
+	dashboard := datadog.Board{
+		Id:          datadog.String(d.Id()),
+		Title:       datadog.String(d.Get("title").(string)),
+		LayoutType:  datadog.String(d.Get("layout_type").(string)),
+		Description: datadog.String(d.Get("description").(string)),
+		IsReadOnly:  datadog.Bool(d.Get("is_read_only").(bool)),
+	}
+
+	// Build Widgets
+	widgets := d.Get("widget").([]interface{})
+	datadogWidgets, err := buildDatadogWidgets(&widgets)
+	if err != nil {
+		return nil, err
+	}
+	dashboard.Widgets = *datadogWidgets
+
+	// Build NotifyList
+	notifyList := d.Get("notify_list").([]interface{})
+	dashboard.NotifyList = buildDatadogNotifyList(&notifyList)
+
+	// Build TemplateVariables
+	templateVariables := d.Get("template_variable").([]interface{})
+	dashboard.TemplateVariables = *buildDatadogTemplateVariables(&templateVariables)
+
+	return &dashboard, nil
+}
+
+func resourceDatadogDashboardCreate(d *schema.ResourceData, meta interface{}) error {
+	dashboard, err := buildDatadogDashboard(d)
+	if err != nil {
+		return fmt.Errorf("Failed to parse resource configuration: %s", err.Error())
+	}
+	dashboard, err = meta.(*datadog.Client).CreateBoard(dashboard)
+	if err != nil {
+		return fmt.Errorf("Failed to create dashboard using Datadog API: %s", err.Error())
+	}
+	d.SetId(*dashboard.Id)
+	return nil
+}
+
+func resourceDatadogDashboardUpdate(d *schema.ResourceData, meta interface{}) error {
+	dashboard, err := buildDatadogDashboard(d)
+	if err != nil {
+		return fmt.Errorf("Failed to parse resource configuration: %s", err.Error())
+	}
+	if err = meta.(*datadog.Client).UpdateBoard(dashboard); err != nil {
+		return fmt.Errorf("Failed to update dashboard using Datadog API: %s", err.Error())
+	}
+	return resourceDatadogDashboardRead(d, meta)
+}
+
+func resourceDatadogDashboardRead(d *schema.ResourceData, meta interface{}) error {
+	id := d.Id()
+	dashboard, err := meta.(*datadog.Client).GetBoard(id)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DataDog] dashboard: %v", pretty.Sprint(dashboard))
+
+	// Set title
+	if err := d.Set("title", dashboard.Title); err != nil {
+		return err
+	}
+	// Set widgets
+	widgets, err := buildTerraformWidgets(&dashboard.Widgets)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("widget", widgets); err != nil {
+		return err
+	}
+	// Set layout type
+	if err := d.Set("layout_type", dashboard.LayoutType); err != nil {
+		return err
+	}
+	// Set description
+	if err := d.Set("description", dashboard.Description); err != nil {
+		return err
+	}
+	// Set is_read_only
+	if err := d.Set("is_read_only", dashboard.IsReadOnly); err != nil {
+		return err
+	}
+	// Set template variables
+	templateVariables := buildTerraformTemplateVariables(&dashboard.TemplateVariables)
+	if err := d.Set("template_variable", templateVariables); err != nil {
+		return err
+	}
+	// Set notify list
+	notifyList := buildTerraformNotifyList(&dashboard.NotifyList)
+	if err := d.Set("notify_list", notifyList); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceDatadogDashboardDelete(d *schema.ResourceData, meta interface{}) error {
+	id := d.Id()
+	if err := meta.(*datadog.Client).DeleteBoard(id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceDatadogDashboardImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceDatadogDashboardRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceDatadogDashboardExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+	id := d.Id()
+	if _, err := meta.(*datadog.Client).GetBoard(id); err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/datadog/resource_datadog_dashboard_test.go
+++ b/datadog/resource_datadog_dashboard_test.go
@@ -1,0 +1,142 @@
+package datadog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MLaureB/go-datadog-api"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const datadogDashboardConfig = `
+resource "datadog_dashboard" "ordered_dashboard" {
+  title         = "Acceptance Test Ordered Dashboard"
+  description   = "Created using the Datadog provider in Terraform"
+  layout_type   = "ordered"
+  is_read_only  = true
+
+  widget {
+  	note_definition {
+      content = "note text"
+      background_color = "pink"
+      font_size = "14"
+      text_align = "center"
+    }
+	}
+
+	widget {
+		group_definition {
+			layout_type = "ordered"
+			title = "Group Widget"
+
+			widget {
+				note_definition {
+					content = "cluster note widget"
+      		background_color = "yellow"
+				}
+			}
+
+			widget {
+				alert_graph_definition {
+					alert_id = "123"
+					viz_type = "toplist"
+					title = "Alert Graph"
+					title_size = "16"
+					title_align = "right"
+					time = {
+						live_span = "1h"
+					}
+				}
+			}
+		}
+	}
+
+  template_variable {
+    name   = "var_1"
+    prefix = "host"
+    default = "aws"
+	}
+
+	template_variable {
+    name   = "var_2"
+    prefix = "service_name"
+    default = "autoscaling"
+	}
+}
+`
+
+func TestAccDatadogDashboard_update(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: datadogDashboardConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkDashboardExists,
+					// Dashboard metadata
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "title", "Acceptance Test Ordered Dashboard"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "description", "Created using the Datadog provider in Terraform"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "layout_type", "ordered"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "is_read_only", "true"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.#", "2"),
+					// Note widget
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.0.note_definition.0.content", "note text"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.0.note_definition.0.background_color", "pink"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.0.note_definition.0.font_size", "14"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.0.note_definition.0.text_align", "center"),
+					// Group widget
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.layout_type", "ordered"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.title", "Group Widget"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.#", "2"),
+					// Inner Note widget
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.0.note_definition.0.content", "cluster note widget"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.0.note_definition.0.background_color", "yellow"),
+					// Inner Alert Graph widget
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.alert_id", "123"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.viz_type", "toplist"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.title", "Alert Graph"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.title_size", "16"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.title_align", "right"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "widget.1.group_definition.0.widget.1.alert_graph_definition.0.time.live_span", "1h"),
+					// Template Variables
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.#", "2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.0.name", "var_1"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.0.prefix", "host"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.0.default", "aws"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.1.name", "var_2"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.1.prefix", "service_name"),
+					resource.TestCheckResourceAttr("datadog_dashboard.ordered_dashboard", "template_variable.1.default", "autoscaling"),
+				),
+			},
+		},
+	})
+}
+
+func checkDashboardExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*datadog.Client)
+	for _, r := range s.RootModule().Resources {
+		if _, err := client.GetBoard(r.Primary.ID); err != nil {
+			return fmt.Errorf("Received an error retrieving dashboard1 %s", err)
+		}
+	}
+	return nil
+}
+
+func checkDashboardDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*datadog.Client)
+	for _, r := range s.RootModule().Resources {
+		if _, err := client.GetBoard(r.Primary.ID); err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				continue
+			}
+			return fmt.Errorf("Received an error retrieving dashboard2 %s", err)
+		}
+		return fmt.Errorf("Timeboard still exists")
+	}
+	return nil
+}

--- a/datadog/resource_datadog_timeboard.go
+++ b/datadog/resource_datadog_timeboard.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/zorkian/go-datadog-api"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kr/pretty"
-	"github.com/zorkian/go-datadog-api"
 )
 
 func resourceDatadogTimeboard() *schema.Resource {


### PR DESCRIPTION
POC to add support for the [new Dashboard API](https://docs.datadoghq.com/api/?lang=python#dashboards) in the Go library.

Note: this POC only supports 4 different types of widgets (Alert Graph, Note and Group widgets), the plan is to support all the different widgets documented [here](https://docs.datadoghq.com/graphing/widgets/).